### PR TITLE
Fix templating for Wiki

### DIFF
--- a/overrides/main.html
+++ b/overrides/main.html
@@ -47,7 +47,7 @@ as the main headline.
 {% if page.meta.git_revision_date_localized or
       page.meta.revision_date
 %}
-  {% include "partials/source-date.html" %}
+  {% include "partials/source-file.html" %}
 {% endif %}
 {% endif %}
 {% endblock %}


### PR DESCRIPTION
The recent version of MKDocs and the git-revision-date plugin have renamed one of the
templating files. Made according change here to allow compilation.